### PR TITLE
BugFix: UserManager.HasPermission

### DIFF
--- a/src/BugNET.BLL/UserManager.cs
+++ b/src/BugNET.BLL/UserManager.cs
@@ -147,19 +147,30 @@ namespace BugNET.BLL
         }
 
         /// <summary>
-        /// Determines if the user is in the super user role
+        /// Determines if the logged-in user is in the super user role
         /// </summary>
         /// <returns>
         /// <c>true</c> if is in role otherwise, <c>false</c>.
         /// </returns>
         public static bool IsSuperUser()
         {
-            if (string.IsNullOrEmpty(HttpContext.Current.User.Identity.Name))
+            return IsSuperUser(HttpContext.Current.User.Identity.Name);
+        }
+
+        /// <summary>
+        /// Determines if the supplied user is in the super user role
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if is in role otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsSuperUser(string username)
+        {
+            if (string.IsNullOrEmpty(username))
             {
                 return false;
             }
 
-            var roles = RoleManager.GetForUser(HttpContext.Current.User.Identity.Name);
+            var roles = RoleManager.GetForUser(username);
             return roles.Exists(r => r.Name == Globals.SUPER_USER_ROLE);
         }
 
@@ -227,7 +238,7 @@ namespace BugNET.BLL
             //if (projectId <= Globals.NEW_ID) throw new ArgumentNullException("projectId");
 
             //return true for all permission checks if the user is in the super users role.
-            if (IsSuperUser()) return true;
+            if (IsSuperUser(userName)) return true;
 
             var roles = RoleManager.GetForUser(userName, projectId);
 

--- a/src/BugNET_WAP/Issues/UserControls/Comments.ascx.cs
+++ b/src/BugNET_WAP/Issues/UserControls/Comments.ascx.cs
@@ -122,7 +122,7 @@ namespace BugNET.Issues.UserControls
             if (HostSettingManager.Get(HostSettingNames.EnableGravatar, true))
             {
                 var user = Membership.GetUser(currentComment.CreatorUserName);
-                if (user != null) avatar.Attributes.Add("src", GetGravatarImageUrl(user.Email, 64));
+                if (user != null && user.Email != null) avatar.Attributes.Add("src", PresentationUtils.GetGravatarImageUrl(user.Email, 64));
             }
 
             var hlPermaLink = (HyperLink)e.Item.FindControl("hlPermalink");
@@ -164,33 +164,6 @@ namespace BugNET.Issues.UserControls
             }
         }
 
-        /// <summary>
-        /// Gets the gravatar image URL.
-        /// </summary>
-        /// <param name="email">The email id.</param>
-        /// <param name="imgSize">Size of the img.</param>
-        /// <returns></returns>
-        private static string GetGravatarImageUrl(string email, int imgSize)
-        {
-            // Convert emailID to lower-case
-            email = email.Trim().ToLower();
-
-            var emailBytes = Encoding.ASCII.GetBytes(email);
-            var hashBytes = new MD5CryptoServiceProvider().ComputeHash(emailBytes);
-
-            Debug.Assert(hashBytes.Length == 16);
-
-            var hash = new StringBuilder();
-            foreach (var b in hashBytes)
-            {
-                hash.Append(b.ToString("x2"));
-            }
-
-            // build Gravatar Image URL
-            var imageUrl = string.Format("http://www.gravatar.com/avatar/{0}?s={1}&d=identicon&r=g", hash, imgSize);
-
-            return imageUrl;
-        }
 
         /// <summary>
         /// Handles the ItemCommand event of the rptComments control.

--- a/src/BugNET_WAP/Site.Master.cs
+++ b/src/BugNET_WAP/Site.Master.cs
@@ -83,7 +83,7 @@ namespace BugNET
             if (HostSettingManager.Get(HostSettingNames.EnableGravatar, true))
             {
                 var user = Membership.GetUser(Security.GetUserName());
-                if (user != null)
+                if (user != null && user.Email != null)
                 {
                     Image img =  (System.Web.UI.WebControls.Image)LoginView1.FindControl("Avatar");
                     img.ImageUrl = PresentationUtils.GetGravatarImageUrl(user.Email, 32);


### PR DESCRIPTION
BugFix: UserManager.HasPermission does not use passed in username in
IsSuperUser() #51
Created new IsSuperUser(username) which is now called by both
HasPermission and IsSuperUser.
As requested: https://github.com/dubeaud/bugnet/issues/51