### PR TITLE
Issues created from mailbox do not fire notifications #82

### DIFF
--- a/src/BugNET.BLL/HostSettingManager.cs
+++ b/src/BugNET.BLL/HostSettingManager.cs
@@ -237,7 +237,7 @@ namespace BugNET.BLL
             {
                 var val = Get(HostSettingNames.SMTPEmailTemplateRoot, "~/templates");
 
-                val = HttpContext.Current.Server.MapPath(val);
+                val = System.Web.Hosting.HostingEnvironment.MapPath(val);
 
                 if (!System.IO.Directory.Exists(val))
                     throw new Exception(string.Format("The configured path: [{0}] does not exist, cannot load Xslt template", val));

--- a/src/BugNET.BLL/IssueNotificationManager.cs
+++ b/src/BugNET.BLL/IssueNotificationManager.cs
@@ -71,7 +71,7 @@ namespace BugNET.BLL
             var emailFormatType = HostSettingManager.Get(HostSettingNames.SMTPEMailFormat, EmailFormatType.Text);
 
             var data = new Dictionary<string, object> { { "Issue", issue } };
- 
+
             var displayname = UserManager.GetUserDisplayName(Security.GetUserName());
 
             var templateCache = new List<CultureNotificationContent>();
@@ -98,9 +98,9 @@ namespace BugNET.BLL
                     if (notification.NotificationUsername.ToLower() == Security.GetUserName().ToLower()) continue;
 
                     var user = UserManager.GetUser(notification.NotificationUsername);
-                    
+
                     // skip to the next user if this user is not approved
-                    if(!user.IsApproved) continue; 
+                    if (!user.IsApproved) continue;
                     // skip to next user if this user doesn't have notifications enabled.
                     if (!new WebProfile().GetProfile(user.UserName).ReceiveEmailNotifications) continue;
 
@@ -146,7 +146,7 @@ namespace BugNET.BLL
             var issNotifications = DataProviderManager.Provider.GetIssueNotificationsByIssueId(issueId);
             var emailFormatType = HostSettingManager.Get(HostSettingNames.SMTPEMailFormat, EmailFormatType.Text);
 
-            var data = new Dictionary<string, object> {{"Issue", issue}};
+            var data = new Dictionary<string, object> { { "Issue", issue } };
 
             var templateCache = new List<CultureNotificationContent>();
             var emailFormatKey = (emailFormatType == EmailFormatType.Text) ? "" : "HTML";
@@ -169,12 +169,12 @@ namespace BugNET.BLL
                 try
                 {
                     //send notifications to everyone except who added it.
-                    if (notification.NotificationUsername.ToLower() == Security.GetUserName().ToLower()) continue;
+                    //if (notification.NotificationUsername.ToLower() == Security.GetUserName().ToLower()) continue;
 
                     var user = UserManager.GetUser(notification.NotificationUsername);
 
                     // skip to the next user if this user is not approved
-                    if (!user.IsApproved) continue; 
+                    if (!user.IsApproved) continue;
                     // skip to next user if this user doesn't have notifications enabled.
                     if (!new WebProfile().GetProfile(user.UserName).ReceiveEmailNotifications) continue;
 
@@ -213,7 +213,7 @@ namespace BugNET.BLL
         {
             // validate input
             if (issueId <= Globals.NEW_ID)
-            { 
+            {
                 throw (new ArgumentOutOfRangeException("issueId"));
             }
 
@@ -224,7 +224,7 @@ namespace BugNET.BLL
             var issNotifications = DataProviderManager.Provider.GetIssueNotificationsByIssueId(issueId);
             var emailFormatType = HostSettingManager.Get(HostSettingNames.SMTPEMailFormat, EmailFormatType.Text);
 
-            var data = new Dictionary<string, object> {{"Issue", issue}};
+            var data = new Dictionary<string, object> { { "Issue", issue } };
 
             var writer = new System.IO.StringWriter();
             using (System.Xml.XmlWriter xml = new System.Xml.XmlTextWriter(writer))
@@ -270,7 +270,7 @@ namespace BugNET.BLL
                     var user = UserManager.GetUser(notification.NotificationUsername);
 
                     // skip to the next user if this user is not approved
-                    if (!user.IsApproved) continue; 
+                    if (!user.IsApproved) continue;
                     // skip to next user if this user doesn't have notifications enabled.
                     if (!new WebProfile().GetProfile(user.UserName).ReceiveEmailNotifications) continue;
 
@@ -312,7 +312,7 @@ namespace BugNET.BLL
             // TODO - create this via dependency injection at some point.
             IMailDeliveryService mailService = new SmtpMailDeliveryService();
 
-        	var issue = DataProviderManager.Provider.GetIssueById(notification.IssueId);
+            var issue = DataProviderManager.Provider.GetIssueById(notification.IssueId);
             var emailFormatType = HostSettingManager.Get(HostSettingNames.SMTPEMailFormat, EmailFormatType.Text);
 
             // data for template
@@ -331,7 +331,7 @@ namespace BugNET.BLL
                 var user = UserManager.GetUser(notification.NotificationUsername);
 
                 // skip to the next user if this user is not approved
-                if (!user.IsApproved) return; 
+                if (!user.IsApproved) return;
                 // skip to next user if this user doesn't have notifications enabled.
                 if (!new WebProfile().GetProfile(user.UserName).ReceiveEmailNotifications)
                     return;
@@ -377,7 +377,7 @@ namespace BugNET.BLL
             var emailFormatType = HostSettingManager.Get(HostSettingNames.SMTPEMailFormat, EmailFormatType.Text);
 
             // data for template
-            var data = new Dictionary<string, object> {{"Issue", issue}, {"Comment", newComment}};
+            var data = new Dictionary<string, object> { { "Issue", issue }, { "Comment", newComment } };
             var displayname = UserManager.GetUserDisplayName(Security.GetUserName());
 
             var templateCache = new List<CultureNotificationContent>();
@@ -416,7 +416,7 @@ namespace BugNET.BLL
                     var user = UserManager.GetUser(notification.NotificationUsername);
 
                     // skip to the next user if this user is not approved
-                    if (!user.IsApproved) continue; 
+                    if (!user.IsApproved) continue;
                     // skip to next user if this user doesn't have notifications enabled.
                     if (!new WebProfile().GetProfile(user.UserName).ReceiveEmailNotifications) continue;
 

--- a/src/BugNET.MailboxReader/BugNET.MailboxReader.csproj
+++ b/src/BugNET.MailboxReader/BugNET.MailboxReader.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
Added a few fixes to add notifications for issues created by email.
I've also comment line 172 in IssueNotificationManager:
- it will throw an errow on background threads because there's no active user
- I think this is incorrect, since if the project has a default configured to send notifications to owner, it should still send the email

