### PR TITLE
Added user info card display on hover

### DIFF
--- a/src/BugNET.Entities/Issue.cs
+++ b/src/BugNET.Entities/Issue.cs
@@ -14,6 +14,7 @@ namespace BugNET.Entities
         /// </summary>
         public Issue()
         {
+            AssignedUser = new ITUser(new Guid(), string.Empty, string.Empty);
             AssignedDisplayName = string.Empty;
             AssignedUserName = string.Empty;
             LastUpdateUserName = string.Empty;
@@ -81,6 +82,12 @@ namespace BugNET.Entities
         /// <value>The time logged.</value>
         public double TimeLogged { get; set; }
 
+
+        /// <summary>
+        /// Gets or sets the assigned user.
+        /// </summary>
+        /// <value>The assigned user.</value>
+        public ITUser AssignedUser { get; set; }
 
         /// <summary>
         /// Gets or sets the display name of the assigned to user.

--- a/src/BugNET.Entities/IssueComment.cs
+++ b/src/BugNET.Entities/IssueComment.cs
@@ -15,6 +15,7 @@ namespace BugNET.Entities
         /// </summary>
         public IssueComment()
         {
+            CreatorUser = new ITUser(new Guid(), string.Empty, string.Empty);
             CreatorUserName = string.Empty;
             Comment = string.Empty;
             CreatorDisplayName = string.Empty;
@@ -89,6 +90,12 @@ namespace BugNET.Entities
         /// </summary>
         /// <value>The issue id.</value>
         public int IssueId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creator user.
+        /// </summary>
+        /// <value>The creator user</value>
+        public ITUser CreatorUser { get; set; }
 
         #endregion
     }

--- a/src/BugNET_WAP/Issues/UserControls/Comments.ascx.cs
+++ b/src/BugNET_WAP/Issues/UserControls/Comments.ascx.cs
@@ -101,6 +101,9 @@ namespace BugNET.Issues.UserControls
 
             var creatorDisplayName = (Label)e.Item.FindControl("CreatorDisplayName");
             creatorDisplayName.Text = UserManager.GetUserDisplayName(currentComment.CreatorUserName);
+            creatorDisplayName.ToolTip = "Id: " + currentComment.CreatorUser.Id + Environment.NewLine + 
+                                         "UserName: " + currentComment.CreatorUser.UserName + Environment.NewLine +
+                                         "DisplayName: " + currentComment.CreatorUser.DisplayName;
 
             var lblDateCreated = (Label)e.Item.FindControl("lblDateCreated");
             lblDateCreated.Text = currentComment.DateCreated.ToString("f");

--- a/src/BugNET_WAP/UserControls/DisplayIssues.ascx
+++ b/src/BugNET_WAP/UserControls/DisplayIssues.ascx
@@ -263,7 +263,9 @@
             </asp:TemplateField>
             <asp:TemplateField HeaderText="<%$ Resources:SharedResources, Assigned %>" Visible="false" SortExpression="AssignedDisplayName">
                 <ItemTemplate>
-                    <%# DataBinder.Eval(Container.DataItem, "AssignedDisplayName" )%>
+                    <div id="AssignedUser" runat="server">
+                        <%# DataBinder.Eval(Container.DataItem, "AssignedDisplayName" )%>
+                    </div>
                 </ItemTemplate>
                 <HeaderStyle Wrap="False" />
                 <ItemStyle Wrap="False" />

--- a/src/BugNET_WAP/UserControls/DisplayIssues.ascx.cs
+++ b/src/BugNET_WAP/UserControls/DisplayIssues.ascx.cs
@@ -540,6 +540,9 @@ namespace BugNET.UserControls
 
             e.Row.FindControl("PrivateIssue").Visible = issue.Visibility != 0;
 
+            ((HtmlControl)e.Row.FindControl("AssignedUser")).Attributes.Add("title", "Id: " + issue.AssignedUser.Id + Environment.NewLine + 
+                                                                                     "UserName: " + issue.AssignedUser.UserName + Environment.NewLine +
+                                                                                     "DisplayName: " + issue.AssignedUser.DisplayName);
             ((HtmlControl)e.Row.FindControl("ProgressBar")).Attributes.CssStyle.Add("width", issue.Progress + "%");
             ((HtmlControl)e.Row.FindControl("ProgressBar")).Attributes.Add("aria-valuenow", issue.Progress.ToString());
         }

--- a/src/Library/Providers/DataProviders/SqlDataProvider/SqlDataProviderListHelpers.cs
+++ b/src/Library/Providers/DataProviders/SqlDataProvider/SqlDataProviderListHelpers.cs
@@ -82,6 +82,10 @@ namespace BugNET.Providers.DataProviders
             {
                 issueCommentList.Add(new IssueComment
                     {
+                        CreatorUser = new ITUser(returnData.GetGuid(returnData.GetOrdinal("CreatorUserId")),
+                                              returnData.GetString(returnData.GetOrdinal("CreatorUsername")),
+                                              returnData.GetString(returnData.GetOrdinal("CreatorDisplayName"))
+                                              ),
                         Id = returnData.GetInt32(returnData.GetOrdinal("IssueCommentId")),
                         Comment = returnData.GetString(returnData.GetOrdinal("Comment")),
                         DateCreated = returnData.GetDateTime(returnData.GetOrdinal("DateCreated")),
@@ -782,6 +786,10 @@ namespace BugNET.Providers.DataProviders
                         returnData.GetString(returnData.GetOrdinal("AssignedDisplayName")),
                     AssignedUserId = DefaultIfNull(returnData["IssueAssignedUserId"], Guid.Empty),
                     AssignedUserName = returnData.GetString(returnData.GetOrdinal("AssignedUserName")),
+                    AssignedUser = new ITUser(DefaultIfNull(returnData["IssueAssignedUserId"], Guid.Empty),
+                                              returnData.GetString(returnData.GetOrdinal("AssignedUserName")),
+                                              returnData.GetString(returnData.GetOrdinal("AssignedDisplayName"))                                              
+                                              ),
                     CategoryId = DefaultIfNull(returnData["IssueCategoryId"], 0),
                     CategoryName = returnData.GetString(returnData.GetOrdinal("CategoryName")),
                     CreatorDisplayName = returnData.GetString(returnData.GetOrdinal("CreatorDisplayName")),


### PR DESCRIPTION
This addresses the request to add a display for user info card on hover,
[issue #64](https://github.com/dubeaud/bugnet/issues/64).

I only added it to the Assigned User on the Issue List and the Creator
User for a comment. If it needs to be added elsewhere, feel free, but
this should be a step in the right direction.

This also requires a change to the `[BugNet_IssuesView]` view to include `AssignedUsers.UserId AS AssignedUserId`.