### PR TITLE
Fixed status shown as text for sub issues 

### DIFF
--- a/src/BugNET.Database/Stored Procedures/BugNet_RelatedIssue_GetChildIssues.sql
+++ b/src/BugNET.Database/Stored Procedures/BugNet_RelatedIssue_GetChildIssues.sql
@@ -8,6 +8,8 @@ SELECT
 	IssueTitle,
 	StatusName as IssueStatus,
 	ResolutionName as IssueResolution,
+	ISNULL(dbo.BugNet_ProjectStatus.StatusName, N'Unassigned') AS StatusName,
+	ISNULL(dbo.BugNet_ProjectStatus.StatusImageUrl, '') AS StatusImageUrl,
 	DateCreated
 FROM
 	BugNet_RelatedIssues

--- a/src/BugNET.Database/Stored Procedures/BugNet_RelatedIssue_GetParentIssues.sql
+++ b/src/BugNET.Database/Stored Procedures/BugNet_RelatedIssue_GetParentIssues.sql
@@ -8,6 +8,8 @@ SELECT
 	IssueTitle,
 	StatusName as IssueStatus,
 	ResolutionName as IssueResolution,
+	ISNULL(dbo.BugNet_ProjectStatus.StatusName, N'Unassigned') AS StatusName,
+	ISNULL(dbo.BugNet_ProjectStatus.StatusImageUrl, '') AS StatusImageUrl,
 	DateCreated
 FROM
 	BugNet_RelatedIssues

--- a/src/BugNET.Database/Stored Procedures/BugNet_RelatedIssue_GetRelatedIssues.sql
+++ b/src/BugNET.Database/Stored Procedures/BugNet_RelatedIssue_GetRelatedIssues.sql
@@ -8,6 +8,8 @@ SELECT
 	IssueTitle,
 	StatusName as IssueStatus,
 	ResolutionName as IssueResolution,
+	ISNULL(dbo.BugNet_ProjectStatus.StatusName, N'Unassigned') AS StatusName,
+	ISNULL(dbo.BugNet_ProjectStatus.StatusImageUrl, '') AS StatusImageUrl,
 	DateCreated
 FROM
 	BugNet_Issues

--- a/src/BugNET.Entities/Issue.cs
+++ b/src/BugNET.Entities/Issue.cs
@@ -14,6 +14,7 @@ namespace BugNET.Entities
         /// </summary>
         public Issue()
         {
+            AssignedUser = new ITUser(new Guid(), string.Empty, string.Empty);
             AssignedDisplayName = string.Empty;
             AssignedUserName = string.Empty;
             LastUpdateUserName = string.Empty;
@@ -81,6 +82,12 @@ namespace BugNET.Entities
         /// <value>The time logged.</value>
         public double TimeLogged { get; set; }
 
+
+        /// <summary>
+        /// Gets or sets the assigned user.
+        /// </summary>
+        /// <value>The assigned user.</value>
+        public ITUser AssignedUser { get; set; }
 
         /// <summary>
         /// Gets or sets the display name of the assigned to user.

--- a/src/BugNET.Entities/IssueComment.cs
+++ b/src/BugNET.Entities/IssueComment.cs
@@ -15,6 +15,7 @@ namespace BugNET.Entities
         /// </summary>
         public IssueComment()
         {
+            CreatorUser = new ITUser(new Guid(), string.Empty, string.Empty);
             CreatorUserName = string.Empty;
             Comment = string.Empty;
             CreatorDisplayName = string.Empty;
@@ -89,6 +90,12 @@ namespace BugNET.Entities
         /// </summary>
         /// <value>The issue id.</value>
         public int IssueId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creator user.
+        /// </summary>
+        /// <value>The creator user</value>
+        public ITUser CreatorUser { get; set; }
 
         #endregion
     }

--- a/src/BugNET.Entities/RelatedIssue.cs
+++ b/src/BugNET.Entities/RelatedIssue.cs
@@ -40,6 +40,20 @@ namespace BugNET.Entities
         /// <value>The status.</value>
         public string Status { get; set; }
 
+
+        /// <summary>
+        /// Gets the name of the status.
+        /// </summary>
+        /// <value>The name of the status.</value>
+        public string StatusName { get; set; }
+
+        /// <summary>
+        /// Gets the status image URL.
+        /// </summary>
+        /// <value>The status image URL.</value>
+        public string StatusImageUrl { get; set; }
+
+
         /// <summary>
         /// Gets the resolution.
         /// </summary>

--- a/src/BugNET_WAP/Issues/UserControls/Comments.ascx.cs
+++ b/src/BugNET_WAP/Issues/UserControls/Comments.ascx.cs
@@ -101,6 +101,9 @@ namespace BugNET.Issues.UserControls
 
             var creatorDisplayName = (Label)e.Item.FindControl("CreatorDisplayName");
             creatorDisplayName.Text = UserManager.GetUserDisplayName(currentComment.CreatorUserName);
+            creatorDisplayName.ToolTip = "Id: " + currentComment.CreatorUser.Id + Environment.NewLine + 
+                                         "UserName: " + currentComment.CreatorUser.UserName + Environment.NewLine +
+                                         "DisplayName: " + currentComment.CreatorUser.DisplayName;
 
             var lblDateCreated = (Label)e.Item.FindControl("lblDateCreated");
             lblDateCreated.Text = currentComment.DateCreated.ToString("f");

--- a/src/BugNET_WAP/Issues/UserControls/ParentIssues.ascx
+++ b/src/BugNET_WAP/Issues/UserControls/ParentIssues.ascx
@@ -1,4 +1,5 @@
 <%@ Control Language="c#" CodeBehind="ParentIssues.ascx.cs" AutoEventWireup="True" Inherits="BugNET.Issues.UserControls.ParentIssues" %>
+<%@ Register TagPrefix="it" TagName="TextImage" Src="~/UserControls/TextImage.ascx" %>
 <p style="margin-bottom:1em">
 	<asp:label ID="lblDescription" meta:resourcekey="lblDescription"  runat="server" />
 </p>
@@ -11,7 +12,14 @@
 		<asp:HyperLinkColumn DataNavigateUrlField="IssueId" DataNavigateUrlFormatString="~/Issues/IssueDetail.aspx?id={0}"
 			DataTextField="Title" SortExpression="IssueTitle" HeaderText="<%$ Resources:SharedResources, Title %>">
 		</asp:HyperLinkColumn>
-        <asp:BoundColumn DataField="Status" SortExpression="IssueStatus" HeaderText="<%$ Resources:SharedResources, Status %>" />
+        <asp:TemplateColumn HeaderText="<%$ Resources:SharedResources, Status %>" SortExpression="IssueStatus">
+            <ItemTemplate>
+                <it:TextImage ID="ctlStatus" ImageDirectory="/Status" Text='<%# DataBinder.Eval(Container.DataItem, "StatusName" )%>' ImageUrl='<%# DataBinder.Eval(Container.DataItem, "StatusImageUrl" )%>'
+                    runat="server" />
+            </ItemTemplate>
+            <ItemStyle CssClass="text-center" />
+            <HeaderStyle CssClass="text-center" />
+        </asp:TemplateColumn>
         <asp:BoundColumn DataField="Resolution" SortExpression="IssueResolution" HeaderText="<%$ Resources:SharedResources, Resolution %>" />
         <asp:TemplateColumn>
             <ItemStyle Width="16px" />

--- a/src/BugNET_WAP/Issues/UserControls/RelatedIssues.ascx
+++ b/src/BugNET_WAP/Issues/UserControls/RelatedIssues.ascx
@@ -1,4 +1,5 @@
 <%@ Control Language="C#" AutoEventWireup="true" CodeBehind="RelatedIssues.ascx.cs" Inherits="BugNET.Issues.UserControls.RelatedIssues" %>
+<%@ Register TagPrefix="it" TagName="TextImage" Src="~/UserControls/TextImage.ascx" %>
 <p style="margin-bottom: 1em">
     <asp:Label ID="lblDescription" meta:resourcekey="lblDescription" runat="server" />
 </p>
@@ -10,7 +11,14 @@
         <asp:BoundColumn DataField="IssueId" SortExpression="IssueId" HeaderText="<%$ Resources:SharedResources, Id %>" />
         <asp:HyperLinkColumn DataNavigateUrlField="IssueId" DataNavigateUrlFormatString="~/Issues/IssueDetail.aspx?id={0}"
             DataTextField="Title" SortExpression="IssueTitle" HeaderText="<%$ Resources:SharedResources, Title %>"></asp:HyperLinkColumn>
-        <asp:BoundColumn DataField="Status" SortExpression="IssueStatus" HeaderText="<%$ Resources:SharedResources, Status %>" />
+        <asp:TemplateColumn HeaderText="<%$ Resources:SharedResources, Status %>" SortExpression="IssueStatus">
+            <ItemTemplate>
+                <it:TextImage ID="ctlStatus" ImageDirectory="/Status" Text='<%# DataBinder.Eval(Container.DataItem, "StatusName" )%>' ImageUrl='<%# DataBinder.Eval(Container.DataItem, "StatusImageUrl" )%>'
+                    runat="server" />
+            </ItemTemplate>
+            <ItemStyle CssClass="text-center" />
+            <HeaderStyle CssClass="text-center" />
+        </asp:TemplateColumn>
         <asp:BoundColumn DataField="Resolution" SortExpression="IssueResolution" HeaderText="<%$ Resources:SharedResources, Resolution %>" />
         <asp:TemplateColumn>
             <ItemStyle Width="16px" />

--- a/src/BugNET_WAP/Issues/UserControls/SubIssues.ascx
+++ b/src/BugNET_WAP/Issues/UserControls/SubIssues.ascx
@@ -1,4 +1,6 @@
 <%@ Control Language="c#" CodeBehind="SubIssues.ascx.cs" AutoEventWireup="True" Inherits="BugNET.Issues.UserControls.SubIssues" %>
+<%@ Register TagPrefix="it" TagName="TextImage" Src="~/UserControls/TextImage.ascx" %>
+
 <p style="margin-bottom:1em">
 	<asp:label ID="lblDescription" meta:resourcekey="lblDescription"  runat="server" />
 </p>
@@ -11,7 +13,14 @@
 		<asp:HyperLinkColumn DataNavigateUrlField="IssueId" DataNavigateUrlFormatString="~/Issues/IssueDetail.aspx?id={0}"
 			DataTextField="Title" SortExpression="IssueTitle" HeaderText="<%$ Resources:SharedResources, Title %>">
 		</asp:HyperLinkColumn>
-        <asp:BoundColumn DataField="Status" SortExpression="IssueStatus" HeaderText="<%$ Resources:SharedResources, Status %>" />
+        <asp:TemplateColumn HeaderText="<%$ Resources:SharedResources, Status %>" SortExpression="IssueStatus">
+            <ItemTemplate>
+                <it:TextImage ID="ctlStatus" ImageDirectory="/Status" Text='<%# DataBinder.Eval(Container.DataItem, "StatusName" )%>' ImageUrl='<%# DataBinder.Eval(Container.DataItem, "StatusImageUrl" )%>'
+                    runat="server" />
+            </ItemTemplate>
+            <ItemStyle CssClass="text-center" />
+            <HeaderStyle CssClass="text-center" />
+        </asp:TemplateColumn>
         <asp:BoundColumn DataField="Resolution" SortExpression="IssueResolution" HeaderText="<%$ Resources:SharedResources, Resolution %>" />
         <asp:TemplateColumn>
             <ItemStyle Width="16px" />

--- a/src/BugNET_WAP/UserControls/DisplayIssues.ascx
+++ b/src/BugNET_WAP/UserControls/DisplayIssues.ascx
@@ -263,7 +263,9 @@
             </asp:TemplateField>
             <asp:TemplateField HeaderText="<%$ Resources:SharedResources, Assigned %>" Visible="false" SortExpression="AssignedDisplayName">
                 <ItemTemplate>
-                    <%# DataBinder.Eval(Container.DataItem, "AssignedDisplayName" )%>
+                    <div id="AssignedUser" runat="server">
+                        <%# DataBinder.Eval(Container.DataItem, "AssignedDisplayName" )%>
+                    </div>
                 </ItemTemplate>
                 <HeaderStyle Wrap="False" />
                 <ItemStyle Wrap="False" />

--- a/src/BugNET_WAP/UserControls/DisplayIssues.ascx.cs
+++ b/src/BugNET_WAP/UserControls/DisplayIssues.ascx.cs
@@ -540,6 +540,9 @@ namespace BugNET.UserControls
 
             e.Row.FindControl("PrivateIssue").Visible = issue.Visibility != 0;
 
+            ((HtmlControl)e.Row.FindControl("AssignedUser")).Attributes.Add("title", "Id: " + issue.AssignedUser.Id + Environment.NewLine + 
+                                                                                     "UserName: " + issue.AssignedUser.UserName + Environment.NewLine +
+                                                                                     "DisplayName: " + issue.AssignedUser.DisplayName);
             ((HtmlControl)e.Row.FindControl("ProgressBar")).Attributes.CssStyle.Add("width", issue.Progress + "%");
             ((HtmlControl)e.Row.FindControl("ProgressBar")).Attributes.Add("aria-valuenow", issue.Progress.ToString());
         }

--- a/src/Library/Providers/DataProviders/SqlDataProvider/SqlDataProviderListHelpers.cs
+++ b/src/Library/Providers/DataProviders/SqlDataProvider/SqlDataProviderListHelpers.cs
@@ -82,6 +82,10 @@ namespace BugNET.Providers.DataProviders
             {
                 issueCommentList.Add(new IssueComment
                     {
+                        CreatorUser = new ITUser(returnData.GetGuid(returnData.GetOrdinal("CreatorUserId")),
+                                              returnData.GetString(returnData.GetOrdinal("CreatorUsername")),
+                                              returnData.GetString(returnData.GetOrdinal("CreatorDisplayName"))
+                                              ),
                         Id = returnData.GetInt32(returnData.GetOrdinal("IssueCommentId")),
                         Comment = returnData.GetString(returnData.GetOrdinal("Comment")),
                         DateCreated = returnData.GetDateTime(returnData.GetOrdinal("DateCreated")),
@@ -782,6 +786,10 @@ namespace BugNET.Providers.DataProviders
                         returnData.GetString(returnData.GetOrdinal("AssignedDisplayName")),
                     AssignedUserId = DefaultIfNull(returnData["IssueAssignedUserId"], Guid.Empty),
                     AssignedUserName = returnData.GetString(returnData.GetOrdinal("AssignedUserName")),
+                    AssignedUser = new ITUser(DefaultIfNull(returnData["IssueAssignedUserId"], Guid.Empty),
+                                              returnData.GetString(returnData.GetOrdinal("AssignedUserName")),
+                                              returnData.GetString(returnData.GetOrdinal("AssignedDisplayName"))                                              
+                                              ),
                     CategoryId = DefaultIfNull(returnData["IssueCategoryId"], 0),
                     CategoryName = returnData.GetString(returnData.GetOrdinal("CategoryName")),
                     CreatorDisplayName = returnData.GetString(returnData.GetOrdinal("CreatorDisplayName")),

--- a/src/Library/Providers/DataProviders/SqlDataProvider/SqlDataProviderListHelpers.cs
+++ b/src/Library/Providers/DataProviders/SqlDataProvider/SqlDataProviderListHelpers.cs
@@ -505,6 +505,8 @@ namespace BugNET.Providers.DataProviders
                         IssueId = returnData.GetInt32(returnData.GetOrdinal("IssueId")),
                         Resolution = DefaultIfNull(returnData["IssueResolution"], string.Empty),
                         Status = DefaultIfNull(returnData["IssueStatus"], string.Empty),
+                        StatusName = DefaultIfNull(returnData["StatusName"], string.Empty),
+                        StatusImageUrl = DefaultIfNull(returnData["StatusImageUrl"], string.Empty),
                         Title = returnData.GetString(returnData.GetOrdinal("IssueTitle"))
                     };
 


### PR DESCRIPTION
This fixes the bug mentioned in [issue #37](dubeaud#37). Status will be shown as the appropriate image in the `Sub Issues`, `Parent Issues` and `Related Issues` tabs. Was previously being displayed as only text. This needs updates to the three stored procedures to include the necessary
fields as well.