### PR TITLE
Uses Application Title as the sender name

### DIFF
--- a/src/BugNET.BLL/Notifications/SmtpMailDeliveryService.cs
+++ b/src/BugNET.BLL/Notifications/SmtpMailDeliveryService.cs
@@ -36,11 +36,11 @@ namespace BugNET.BLL.Notifications
             {
                 int at = HostSettingManager.HostEmailAddress.IndexOf("@");
                 string issueCode = string.Format("+iid-{0}", relatedIssueId.Value);
-                message.From = new MailAddress(HostSettingManager.HostEmailAddress.Insert(at, issueCode));
+                message.From = new MailAddress(HostSettingManager.HostEmailAddress.Insert(at, issueCode), HostSettingManager.ApplicationTitle);
             }
             else
             {
-                message.From = new MailAddress(HostSettingManager.HostEmailAddress);
+                message.From = new MailAddress(HostSettingManager.HostEmailAddress, HostSettingManager.ApplicationTitle);
             }
 
 


### PR DESCRIPTION
Uses the application title for the sender name, adding a potential fix for issue #169 