### PR TITLE
Adding attachment storage type to project creation

### DIFF
--- a/src/BugNET.Entities/Project.cs
+++ b/src/BugNET.Entities/Project.cs
@@ -55,7 +55,7 @@ namespace BugNET.Entities
         ///// Gets or sets the type of the attachment storage.
         ///// </summary>
         ///// <value>The type of the attachment storage.</value>
-        //public IssueAttachmentStorageTypes AttachmentStorageType { get; set; }
+        public IssueAttachmentStorageTypes AttachmentStorageType { get; set; }
 
         /// <summary>
         /// Gets or sets the code.

--- a/src/BugNET_WAP/Administration/Projects/UserControls/App_LocalResources/ProjectDescription.ascx.resx
+++ b/src/BugNET_WAP/Administration/Projects/UserControls/App_LocalResources/ProjectDescription.ascx.resx
@@ -171,4 +171,13 @@
   <data name="SecurityTitle.Text" xml:space="preserve">
     <value>Security</value>
   </data>
+  <data name="AttachmentStorageTypeDb.Text" xml:space="preserve">
+    <value>Database &amp;mdash; Attachments and metadata are stored in the database</value>
+  </data>
+  <data name="AttachmentStorageTypeFs.Text" xml:space="preserve">
+    <value>File System  &amp;mdash; Attachments are stored to a specified path on the file system and metadata is stored in the database</value>
+  </data>
+  <data name="AttachmentStorageTypeLabel.Text" xml:space="preserve">
+    <value>Storage Type</value>
+  </data>
 </root>

--- a/src/BugNET_WAP/Administration/Projects/UserControls/ProjectDescription.ascx
+++ b/src/BugNET_WAP/Administration/Projects/UserControls/ProjectDescription.ascx
@@ -70,6 +70,16 @@
             <asp:FileUpload ID="ProjectImageUploadFile" runat="server" />
         </div>
     </div>
+	<div class="form-group" id="AttachmentStorageTypeRow" runat="server">
+		<asp:Label ID="Label12" CssClass="col-md-2 control-label"
+			AssociatedControlID="AttachmentStorageType" meta:resourcekey="AttachmentStorageTypeLabel" runat="server" Text="Storage Type"></asp:Label>
+		<div class="col-md-8">
+			<asp:RadioButtonList ID="AttachmentStorageType" CssClass="radio" RepeatLayout="Flow" RepeatDirection="Vertical" runat="server">
+				<asp:ListItem Text="Database" Selected="True" Value="2" meta:resourcekey="AttachmentStorageTypeDb" />
+				<asp:ListItem Text="File System" Value="1" meta:resourcekey="AttachmentStorageTypeFs" />
+			</asp:RadioButtonList>
+		</div>
+	</div>
     <div class="form-group">
         <div class="col-md-2 col-md-offset-2">
             <asp:Image runat="server" ID="ProjectImage" Height="62" Width="62" />

--- a/src/BugNET_WAP/Administration/Projects/UserControls/ProjectDescription.ascx.cs
+++ b/src/BugNET_WAP/Administration/Projects/UserControls/ProjectDescription.ascx.cs
@@ -141,7 +141,8 @@ namespace BugNET.Administration.Projects.UserControls
                     projectImage = new ProjectImage(ProjectId, fileBytes, uploadedFileName, fileSize, uploadFile.ContentType);
                 }
 
-                var project = new Project
+				var attachmentStorageType = (IssueAttachmentStorageTypes)Enum.Parse(typeof(IssueAttachmentStorageTypes), AttachmentStorageType.SelectedItem.Value);
+				var project = new Project
                                       {
                                           AccessType = at,
                                           Name = txtName.Text.Trim(),
@@ -156,8 +157,9 @@ namespace BugNET.Administration.Projects.UserControls
                                           Image = projectImage,
                                           ManagerDisplayName = string.Empty,
                                           ManagerUserName = ProjectManager.SelectedValue,
-                                          SvnRepositoryUrl = string.Empty
-                                      };
+                                          SvnRepositoryUrl = string.Empty,
+										  AttachmentStorageType = attachmentStorageType
+				};
 
                 if (BLL.ProjectManager.SaveOrUpdate(project))
                 {

--- a/src/BugNET_WAP/Administration/Projects/UserControls/ProjectDescription.ascx.designer.cs
+++ b/src/BugNET_WAP/Administration/Projects/UserControls/ProjectDescription.ascx.designer.cs
@@ -220,6 +220,33 @@ namespace BugNET.Administration.Projects.UserControls {
         protected global::System.Web.UI.WebControls.FileUpload ProjectImageUploadFile;
         
         /// <summary>
+        /// AttachmentStorageTypeRow control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl AttachmentStorageTypeRow;
+        
+        /// <summary>
+        /// Label12 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label Label12;
+        
+        /// <summary>
+        /// AttachmentStorageType control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.RadioButtonList AttachmentStorageType;
+        
+        /// <summary>
         /// ProjectImage control.
         /// </summary>
         /// <remarks>

--- a/src/Library/Providers/DataProviders/SqlDataProvider/SqlDataProvider.cs
+++ b/src/Library/Providers/DataProviders/SqlDataProvider/SqlDataProvider.cs
@@ -1166,7 +1166,9 @@ namespace BugNET.Providers.DataProviders
                 AddParamToSqlCmd(sqlCmd, "@ProjectCode", SqlDbType.NVarChar, 80, ParameterDirection.Input, newProject.Code);
                 AddParamToSqlCmd(sqlCmd, "@SvnRepositoryUrl", SqlDbType.NVarChar, 0, ParameterDirection.Input, newProject.SvnRepositoryUrl);
                 AddParamToSqlCmd(sqlCmd, "@AllowIssueVoting", SqlDbType.Bit, 0, ParameterDirection.Input, newProject.AllowIssueVoting);
-                if (newProject.Image != null)
+				AddParamToSqlCmd(sqlCmd, "@AttachmentStorageType", SqlDbType.Int, 0, ParameterDirection.Input, newProject.AttachmentStorageType);
+
+				if (newProject.Image != null)
                 {
                     AddParamToSqlCmd(sqlCmd, "@ProjectImageFileContent", SqlDbType.Binary, 0, ParameterDirection.Input, newProject.Image.ImageContent);
                     AddParamToSqlCmd(sqlCmd, "@ProjectImageFileName", SqlDbType.NVarChar, 150, ParameterDirection.Input, newProject.Image.ImageFileName);
@@ -1313,6 +1315,8 @@ namespace BugNET.Providers.DataProviders
                 AddParamToSqlCmd(sqlCmd, "@ProjectCode", SqlDbType.NVarChar, 80, ParameterDirection.Input, projectToUpdate.Code);
                 AddParamToSqlCmd(sqlCmd, "@SvnRepositoryUrl", SqlDbType.NVarChar, 0, ParameterDirection.Input, projectToUpdate.SvnRepositoryUrl);
                 AddParamToSqlCmd(sqlCmd, "@AllowIssueVoting", SqlDbType.Bit, 0, ParameterDirection.Input, projectToUpdate.AllowIssueVoting);
+				AddParamToSqlCmd(sqlCmd, "@AttachmentStorageType", SqlDbType.Int, 0, ParameterDirection.Input, projectToUpdate.AttachmentStorageType);
+
                 if (projectToUpdate.Image == null)
                 {
                     AddParamToSqlCmd(sqlCmd, "@ProjectImageFileContent", SqlDbType.Binary, 0, ParameterDirection.Input, DBNull.Value);


### PR DESCRIPTION
This was causing issues when I was creating projects on my local machine, I have tried to retrofit logic from the attachment settings user control, but you should be aware that the stored procedure to create projects fails as this parameter is not specified in the unchanged code
